### PR TITLE
abr-testing: add partial tip protocols for 96 channel

### DIFF
--- a/abr_testing/96_channel_partial_tip_protocols/Phytip_IMAC_Flex_p1k_96ch_H1_rss_updated.py
+++ b/abr_testing/96_channel_partial_tip_protocols/Phytip_IMAC_Flex_p1k_96ch_H1_rss_updated.py
@@ -1,0 +1,89 @@
+from opentrons.protocol_api import COLUMN, EMPTY
+
+
+metadata = {
+    'protocolName': 'Biotage PhyTip IMAC Columns - Flex w/ 96 channel pipette (partial tip configuration)',
+    'author': 'Boren Lin, Opentrons',
+    'source': ''
+}
+
+requirements = {
+    "robotType": "Flex",
+    "apiLevel": "2.16",
+}
+
+NUM_SAMPLE = 24
+
+global cols
+cols = int(NUM_SAMPLE*2//8)
+if NUM_SAMPLE*2%8 != 0: cols = cols + 1
+
+# liquid volume uL 
+VOL_EQL = 1000
+VOL_SAMPLE = 500
+VOL_WASH1 = 1000
+VOL_WASH2 = 1000
+VOL_ELN = 500
+
+CYCLES_EQL = 2
+CYCLES_SAMPLE = 6
+CYCLES_WASH1 = 2
+CYCLES_WASH2 = 2
+CYCLES_ELN = 6
+
+# pipet flow rate uL/s 
+FLOWRATE_EQL = 8
+FLOWRATE_SAMPLE = 4
+FLOWRATE_WASH1 = 8
+FLOWRATE_WASH2 = 8
+FLOWRATE_ELN = 4
+
+def run(ctx):
+
+    # load labware and pipette
+    phytiprack = ctx.load_labware('opentrons_flex_96_tiprack_1000ul', 'B3')  
+    m1k = ctx.load_instrument('flex_96channel_1000', 'left', tip_racks=[phytiprack]) 
+    m1k.configure_nozzle_layout(style=COLUMN, start="A12")
+
+    default_rate = 700
+    m1k.flow_rate.aspirate = default_rate
+    m1k.flow_rate.dispense = default_rate 
+
+    sample_plate = ctx.load_labware('nest_96_wellplate_2ml_deep', 'D1', 'samples plate')
+    equilibration_plate = ctx.load_labware('nest_96_wellplate_2ml_deep', 'C1', 'equilibration plate')
+    wash1_plate = ctx.load_labware('nest_96_wellplate_2ml_deep', 'C2', 'wash plate 1')
+    wash2_plate = ctx.load_labware('nest_96_wellplate_2ml_deep', 'B2', 'wash plate 2')
+    elution_plate = ctx.load_labware('nest_96_wellplate_2ml_deep', 'A2', 'elute plate')
+    placeholder_labware_for_height = ctx.load_adapter('opentrons_flex_96_tiprack_adapter', "A1")
+
+    sample = sample_plate.rows()[0][:cols]
+    eql = equilibration_plate.rows()[0][:cols]
+    wash1 = wash1_plate.rows()[0][:cols]
+    wash2 = wash2_plate.rows()[0][:cols]
+    eln = elution_plate.rows()[0][:cols]
+    waste_chute = ctx.load_waste_chute()
+
+    # mix sequences
+    def plate_mix(cycles, volume, loc, rate, delay=20): # Changed delay from 20 to 0 for test run
+        # m1k.flow_rate.aspirate = rate    # Uncomment for real run
+        # m1k.flow_rate.dispense = rate    # Uncomment for real run
+        for _ in range(cycles):
+            m1k.aspirate(volume*0.9, loc.bottom(z=1))
+            ctx.delay(seconds=delay)
+            m1k.dispense(volume*0.9, loc.bottom(z=1))
+            ctx.delay(seconds=0)   # Changed delay from 10 to 0 for test run
+        m1k.move_to(loc.top(z=5))
+        ctx.delay(seconds=0)       # Changed delay from 10 to 0 for test run
+
+    # perform
+    for i in range(cols):
+        # Workaround for not having tip tracking for partial tip yet
+        tip_column = "A"+ str(i+1)
+
+        m1k.pick_up_tip(phytiprack.wells_by_name()[tip_column])
+        plate_mix(CYCLES_EQL, VOL_EQL, eql[i], FLOWRATE_EQL)
+        plate_mix(CYCLES_SAMPLE, VOL_SAMPLE, sample[i], FLOWRATE_SAMPLE)
+        plate_mix(CYCLES_WASH1, VOL_WASH1, wash1[i], FLOWRATE_WASH1)
+        plate_mix(CYCLES_WASH2, VOL_WASH2, wash2[i], FLOWRATE_WASH2)
+        plate_mix(CYCLES_ELN, VOL_ELN, eln[i], FLOWRATE_ELN)
+        m1k.drop_tip(waste_chute)

--- a/abr_testing/96_channel_partial_tip_protocols/single_col_and_full_tip_config_with_waste_chute.py
+++ b/abr_testing/96_channel_partial_tip_protocols/single_col_and_full_tip_config_with_waste_chute.py
@@ -1,0 +1,45 @@
+from opentrons.protocol_api import COLUMN, EMPTY
+
+
+requirements = {
+	"robotType": "Flex",
+	"apiLevel": "2.16"
+}
+
+def run(protocol_context):
+
+	tip_rack1 = protocol_context.load_labware("opentrons_flex_96_tiprack_50ul", "B3")
+	#tip_rack2 = protocol_context.load_labware("opentrons_flex_96_tiprack_50ul", "B3")
+	instrument = protocol_context.load_instrument('flex_96channel_1000', mount="left", tip_racks=[tip_rack1])
+	my_pcr_plate = protocol_context.load_labware('nest_96_wellplate_200ul_flat', "B2")
+	my_other_pcr_plate = protocol_context.load_labware('nest_96_wellplate_200ul_flat', "C2")
+
+	waste_chute = protocol_context.load_waste_chute()
+
+	# This will set the 96 channel to use its last nozzle column to pick up tips.
+	# This essentially configures the 96-channel to run as an 8-channel pipette
+	# Currently 'column' with starting nozzle 'A12' is the only config available
+	instrument.configure_nozzle_layout(style=COLUMN, start="A12")
+
+	# will pick up tips from column 1 of tiprack, with column 12 nozzles
+	instrument.pick_up_tip()
+
+	# will aspirate 50uL in each tip from column 4 of my_pcr_plate
+	# labware to the left of my_pcr_plate shouldn't be taller than the height to which the 96-channel lowers down to
+	instrument.aspirate(50, my_pcr_plate.wells_by_name()["A4"])
+
+	# should error out because cannot move to partial column
+	# instrument.dispense(30, other_labware.wells_by_name()["B5"])
+
+	# # should error out because return tip not allowed in partial tip configuration
+	# instrument.return_tip()
+
+	# will drop tip in waste chute
+	instrument.drop_tip(waste_chute)
+
+
+	instrument.configure_nozzle_layout(style=EMPTY)
+
+	instrument.pick_up_tip(tip_rack1.wells_by_name()["A1"])
+
+	instrument.drop_tip(waste_chute)

--- a/abr_testing/96_channel_partial_tip_protocols/single_column_with_waste_chute_protocol.py
+++ b/abr_testing/96_channel_partial_tip_protocols/single_column_with_waste_chute_protocol.py
@@ -1,0 +1,40 @@
+from opentrons.protocol_api import COLUMN, EMPTY
+
+
+requirements = {
+	"robotType": "Flex",
+	"apiLevel": "2.16"
+}
+
+def run(protocol_context):
+
+	tip_rack1 = protocol_context.load_labware("opentrons_flex_96_tiprack_50ul", "B3")
+	#tip_rack2 = protocol_context.load_labware("opentrons_flex_96_tiprack_50ul", "B3")
+	
+	instrument = protocol_context.load_instrument('flex_96channel_1000', mount="left", tip_racks=[tip_rack1])
+	my_pcr_plate = protocol_context.load_labware('nest_96_wellplate_200ul_flat', "B2")
+	my_other_pcr_plate = protocol_context.load_labware('nest_96_wellplate_200ul_flat', "C2")
+
+	waste_chute = protocol_context.load_waste_chute()
+
+	# This will set the 96 channel to use its last nozzle column to pick up tips.
+	# This essentially configures the 96-channel to run as an 8-channel pipette
+	# Currently 'column' with starting nozzle 'A12' is the only config available
+	instrument.configure_nozzle_layout(style=COLUMN, start="A12")
+
+	# will pick up tips from column 1 of tiprack, with column 12 nozzles
+	instrument.pick_up_tip()
+
+	# will aspirate 50uL in each tip from column 4 of my_pcr_plate.
+	# labware to the left of my_pcr_plate shouldn't be taller than the height to which the 96-channel lowers down to
+	instrument.aspirate(50, my_pcr_plate.wells_by_name()["A4"])
+
+	# should error out because cannot move to partial column
+	# instrument.dispense(30, other_labware.wells_by_name()["B5"])
+
+	# # should error out because return tip not allowed in partial tip configuration
+	# instrument.return_tip()
+
+	# will drop tip in default trash (or waste chute)
+	instrument.drop_tip(waste_chute)
+


### PR DESCRIPTION
Adds 3 protocols for testing partial tip/nozzle configuration for the 96 channel:
1. `single_column_with_waste_chute_protocol.py`: quick test to pickup 1 column of 96-channel tips & drop it into the waste chute
2. `single_col_and_full_tip_config_with_waste_chute.py`: quick test to pickup 1 column of 96-channel tips, drop it into waste chute, then reset nozzle config to use all 96 tips, pickup tips and drop them all into the waste chute
3. `Phytip_IMAC_Flex_p1k_96ch_H1_rss_updated.py`: protocol written by the science team that uses the 96-channel as an 8-channel